### PR TITLE
Fix: Implement OTP deletion after verification

### DIFF
--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -1,0 +1,26 @@
+package controllers
+
+import (
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"os"
+)
+
+func GenerateJWT(phone string) (string, error) {
+	secretKey := os.Getenv("JWT_SECRET")
+
+	claims := jwt.MapClaims{
+		"phone": phone,
+		"exp": time.Now().Add(time.Hour * 24).Unix(),
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signedToken, err := token.SignedString([]byte(secretKey))
+
+	if err != nil {
+		return "", err
+	}
+
+	return signedToken, nil
+}

--- a/database/database.go
+++ b/database/database.go
@@ -92,3 +92,16 @@ func GetOTP(phone string) (string, error) {
 	log.Println("OTP retrieved:", otp)
 	return otp, nil
 }
+
+func DeleteOTP(phone string) error {
+	ctx := context.Background()
+
+	err := RedisClient.Del(ctx, phone).Err()
+	if err != nil {
+		log.Println("Error deleting OTP for phone:", phone, err)
+		return fmt.Errorf("failed to delete OTP: %v", err)
+	}
+
+	log.Println("OTP deleted for phone:", phone)
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.23.7
 require (
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/gofiber/fiber/v2 v2.52.6
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/joho/godotenv v1.5.1
 	github.com/lib/pq v1.10.9

--- a/main.go
+++ b/main.go
@@ -8,11 +8,42 @@ import (
 
 	"github.com/nvrakesh06/auth-otp-service/database"
 	"github.com/nvrakesh06/auth-otp-service/controllers"
+	"github.com/nvrakesh06/auth-otp-service/middleware"
 )
 
 type OTPRequest struct {
 	Phone string `json:"phone"`
 	Email string `json:"email"`
+}
+
+type VerifyOTPRequest struct {
+	Phone string `json:"phone"`
+	OTP   string `json:"otp"`
+}
+
+func verifyOTP(c *fiber.Ctx) error {
+	var request VerifyOTPRequest
+
+	if err := c.BodyParser(&request); err != nil {
+		return c.Status(400).JSON(fiber.Map{"error": "Invalid request format"})
+	}
+
+	storedOTP, err := database.GetOTP(request.Phone)
+	if err != nil || storedOTP != request.OTP {
+		return c.Status(400).JSON(fiber.Map{"error": "Invalid OTP or expired"})
+	}
+
+	token, err := controllers.GenerateJWT(request.Phone)
+	if err != nil {
+		return c.Status(500).JSON(fiber.Map{"error": "Failed to generate token"})
+	}
+
+	database.DeleteOTP(request.Phone)
+
+	return c.JSON(fiber.Map{
+		"message": "OTP Verified!",
+		"token":   token,
+	})
 }
 
 func sendOTP(c *fiber.Ctx) error {
@@ -65,6 +96,10 @@ func main() {
 	})
 	app.Post("/send-otp", sendOTP)
 	app.Get("/get-otp", getStoredOTP)
+	app.Post("/verify-otp", verifyOTP)
+	app.Get("/protected", middleware.JWTMiddleware(), func(c *fiber.Ctx) error {
+		return c.JSON(fiber.Map{"message": "You have access to this protected route!"})
+	})
 
 	log.Fatal(app.Listen(":8080"))
 }

--- a/middleware/authMiddleware.go
+++ b/middleware/authMiddleware.go
@@ -1,0 +1,30 @@
+package middleware
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/golang-jwt/jwt/v5"
+	"os"
+)
+
+func JWTMiddleware() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		tokenString := c.Get("Authorization")
+		if tokenString == "" {
+			return c.Status(401).JSON(fiber.Map{"error": "Unauthorized"})
+		}
+
+		if len(tokenString) > 7 && tokenString[:7] == "Bearer " {
+			tokenString = tokenString[7:]
+		}
+
+		token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+			return []byte(os.Getenv("JWT_SECRET")), nil
+		})
+
+		if err != nil || !token.Valid {
+			return c.Status(401).JSON(fiber.Map{"error": "Invalid token"})
+		}
+
+		return c.Next()
+	}
+}


### PR DESCRIPTION
- Added `DeleteOTP()` function to remove OTP from Redis after successful verification.
- Integrated `DeleteOTP()` in `verifyOTP()` function to ensure expired OTPs don't persist.
- Logged OTP deletion for better debugging and monitoring.
- Verified OTP is removed from Redis after authentication.