### PR TITLE
feat: Store OTP in PostgreSQL & optimize OTP handling flows

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,6 +15,7 @@ func main() {
 
 	database.ConnectPostgres()
 	database.ConnectRedis()
+	database.ExpireOldOTPs() // TODO: test this flow and check if there's better way to handle this
 
 	app := fiber.New()
 

--- a/controllers/otp_controller.go
+++ b/controllers/otp_controller.go
@@ -7,31 +7,25 @@ import (
 	"github.com/nvrakesh06/auth-otp-service/services"
 )
 
-// OTPRequest struct for API request payload
 type OTPRequest struct {
 	Phone string `json:"phone"`
 	Email string `json:"email"`
 }
 
-// VerifyOTPRequest struct for OTP verification
 type VerifyOTPRequest struct {
 	Phone string `json:"phone"`
 	OTP   string `json:"otp"`
 }
 
-// SendOTP generates and stores an OTP
 func SendOTP(c *fiber.Ctx) error {
 	var request OTPRequest
 
-	// Parse JSON request
 	if err := c.BodyParser(&request); err != nil {
 		return c.Status(400).JSON(fiber.Map{"error": "Invalid request format"})
 	}
 
-	// Generate OTP
 	otp := services.GenerateOTP()
 
-	// Save OTP in Redis
 	err := services.SaveOTP(request.Phone, otp)
 	if err != nil {
 		return c.Status(500).JSON(fiber.Map{"error": "Failed to store OTP"})

--- a/database/expire.go
+++ b/database/expire.go
@@ -1,0 +1,23 @@
+package database
+
+import (
+	"log"
+	"time"
+)
+
+func ExpireOldOTPs() {
+	ticker := time.NewTicker(5 * time.Minute)
+	go func() {
+		for range ticker.C {
+			query := `UPDATE otp_requests 
+			          SET status='expired', last_updated=NOW() 
+			          WHERE status='alive' AND expires_at < NOW()`
+			_, err := DB.Exec(query)
+			if err != nil {
+				log.Println("⚠️ Failed to update expired OTPs:", err)
+			} else {
+				log.Println("✅ Expired OTPs updated successfully!")
+			}
+		}
+	}()
+}

--- a/database/init.sql
+++ b/database/init.sql
@@ -1,0 +1,31 @@
+-- Ensure the database is created
+CREATE DATABASE otp_service;
+
+\c otp_service;
+
+-- Create ENUM type for OTP status
+DO $$ 
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'otp_status_enum') THEN
+        CREATE TYPE otp_status_enum AS ENUM ('alive', 'consumed', 'expired', 'duplicate');
+    END IF;
+END $$;
+
+-- Create OTP Requests table if it doesn't exist
+CREATE TABLE IF NOT EXISTS otp_requests (
+    id SERIAL PRIMARY KEY,
+    phone VARCHAR(20) NOT NULL,
+    otp VARCHAR(6) NOT NULL,
+    status otp_status_enum DEFAULT 'alive',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    expires_at TIMESTAMP DEFAULT (CURRENT_TIMESTAMP + INTERVAL '5 minutes'),
+    last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+-- ✅ Ensure the index exists on `expires_at`
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_otp_expires_at') THEN
+        CREATE INDEX idx_otp_expires_at ON otp_requests (expires_at);
+    END IF;
+END $$;

--- a/database/postgres.go
+++ b/database/postgres.go
@@ -27,6 +27,7 @@ func ConnectPostgres() {
 		DB, err = sqlx.Connect("postgres", dsn)
 		if err == nil {
 			log.Println("✅ Connected to PostgreSQL successfully!")
+			ensureTableExists()
 			return
 		}
 
@@ -36,5 +37,40 @@ func ConnectPostgres() {
 
 	if err != nil {
 		log.Fatal("❌ Failed to connect to PostgreSQL:", err)
+	}
+}
+
+func ensureTableExists() {
+	query := `
+	DO $$ 
+	BEGIN
+	    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'otp_status_enum') THEN
+	        CREATE TYPE otp_status_enum AS ENUM ('alive', 'consumed', 'expired', 'duplicate');
+	    END IF;
+	END $$;
+
+	CREATE TABLE IF NOT EXISTS otp_requests (
+	    id SERIAL PRIMARY KEY,
+	    phone VARCHAR(20) NOT NULL,
+	    otp VARCHAR(6) NOT NULL,
+	    status otp_status_enum DEFAULT 'alive',
+	    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+	    expires_at TIMESTAMP DEFAULT (CURRENT_TIMESTAMP + INTERVAL '5 minutes'),
+	    last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+	);
+
+	DO $$
+	BEGIN
+	    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_otp_expires_at') THEN
+	        CREATE INDEX idx_otp_expires_at ON otp_requests (expires_at);
+	    END IF;
+	END $$;
+	`
+
+	_, err := DB.Exec(query)
+	if err != nil {
+		log.Fatal("❌ Error creating table:", err)
+	} else {
+		log.Println("✅ Table `otp_requests` ensured in PostgreSQL!")
 	}
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,7 @@ services:
       - "5432:5432"
     volumes:
       - postgres_otp_data:/var/lib/postgresql/data
+      - ./database/init.sql:/docker-entrypoint-initdb.d/init.sql
 
   redis:
     image: redis:latest

--- a/services/otp_service.go
+++ b/services/otp_service.go
@@ -7,6 +7,7 @@ import (
 	"time"
 	"log"
 
+	"github.com/go-redis/redis/v8"
 	"github.com/nvrakesh06/auth-otp-service/database"
 )
 
@@ -17,11 +18,35 @@ func GenerateOTP() string {
 
 func SaveOTP(phone string, otp string) error {
 	ctx := context.Background()
-	expiration := 5 * time.Minute // OTP expires in 5 minutes
 
-	err := database.RedisClient.Set(ctx, phone, otp, expiration).Err()
+	_, err := database.RedisClient.Get(ctx, phone).Result()
+	if err != nil && err != redis.Nil {
+		return fmt.Errorf("redis error: %v", err)
+	}
+
+	if err == nil {
+		delErr := database.RedisClient.Del(ctx, phone).Err()
+		if delErr != nil {
+			fmt.Printf("⚠️ Failed to delete existing OTP from Redis: %v\n", delErr)
+		}
+
+		updateQuery := `UPDATE otp_requests SET status='duplicate', last_updated=NOW() WHERE phone=$1 AND status='alive'`
+		_, dbErr := database.DB.Exec(updateQuery, phone)
+		if dbErr != nil {
+			return fmt.Errorf("failed to update existing OTP status in PostgreSQL: %v", dbErr)
+		}
+	}
+
+	expiration := 5 * time.Minute
+	err = database.RedisClient.Set(ctx, phone, otp, expiration).Err()
 	if err != nil {
-		return fmt.Errorf("failed to store OTP: %v", err)
+		return fmt.Errorf("failed to store OTP in Redis: %v", err)
+	}
+
+	query := `INSERT INTO otp_requests (phone, otp, status, created_at, expires_at, last_updated) VALUES ($1, $2, 'alive', $3, $4, NOW())`
+	_, err = database.DB.Exec(query, phone, otp, time.Now(), time.Now().Add(expiration))
+	if err != nil {
+		return fmt.Errorf("failed to store OTP in PostgreSQL: %v", err)
 	}
 
 	return nil
@@ -56,12 +81,18 @@ func VerifyOTP(phone string, otp string) (bool, error) {
 	}
 
 	if storedOTP != otp {
-		return false, fmt.Errorf("Invalid OTP")
+		return false, fmt.Errorf("invalid OTP")
 	}
 
 	err = database.RedisClient.Del(ctx, phone).Err()
 	if err != nil {
-		return false, fmt.Errorf("Failed to delete OTP after verification")
+		return false, fmt.Errorf("failed to delete OTP after verification")
+	}
+
+	updateQuery := `UPDATE otp_requests SET status='consumed', last_updated=NOW() WHERE phone=$1 AND status='alive'`
+	_, err = database.DB.Exec(updateQuery, phone)
+	if err != nil {
+		return false, fmt.Errorf("failed to update OTP status")
 	}
 
 	return true, nil


### PR DESCRIPTION
- Added PostgreSQL storage for OTPs to ensure persistence
- Mark old OTPs as `duplicate` when a new OTP is generated
- Optimized Redis handling: delete existing OTP before storing a new one
- Implemented automatic OTP expiry updates in PostgreSQL
- Created an index on `expires_at` for faster queries
- Added background job to mark `alive` OTPs as `expired`
- Ensured Redis cleanup after OTP verification to free up memory
- Improved error handling for Redis and PostgreSQL failures